### PR TITLE
update movement template shaders

### DIFF
--- a/mod/src/StarWarsLegion.lua
+++ b/mod/src/StarWarsLegion.lua
@@ -152,20 +152,20 @@ function onload(saveData)
     templateInfo.moveTemplate[1].colorTint = {1,1,1}
     templateInfo.moveTemplate[1].shortBundle = "http://cloud-3.steamusercontent.com/ugc/1761462778007615968/4EE8D2332DCB6F4837551255CE5B1F240937BBE5/"
     templateInfo.moveTemplate[1].longBundle = "http://cloud-3.steamusercontent.com/ugc/1848161512056297932/A762E187E43177F01CD89D1348F51B1E3C1C744D/"
-    templateInfo.moveTemplate[1].sharedBundle = "http://cloud-3.steamusercontent.com/ugc/1761462778009533333/AD7C02CEE53FB4B2EA823B3DFE570674F8998019/"
+    templateInfo.moveTemplate[1].sharedBundle = "https://steamusercontent-a.akamaihd.net/ugc/14063680635734530221/FCD291B71472CA8636D00D0B82B1BA02671FF414/"
 
 
     templateInfo.moveTemplate[2] = {}
     templateInfo.moveTemplate[2].colorTint = {0.5,0.5,0.5}
     templateInfo.moveTemplate[2].shortBundle = "http://cloud-3.steamusercontent.com/ugc/1761462778009510155/77119B471FE3C51B06443F8ABE1C1B522431DF9B/"
     templateInfo.moveTemplate[2].longBundle = "http://cloud-3.steamusercontent.com/ugc/1761462778009510102/15B368A8D753AB35E1D60F7A377AE273EBEC0145/"
-    templateInfo.moveTemplate[2].sharedBundle = "http://cloud-3.steamusercontent.com/ugc/1761462778009533401/0FBA682D7D5AA7DA1A7EFC18B33C71EB1C0898E4/"
+    templateInfo.moveTemplate[2].sharedBundle = "https://steamusercontent-a.akamaihd.net/ugc/10737538167305927398/637135B07177CA895B71593EB85563FEFD0567D7/"
 
     templateInfo.moveTemplate[3] = {}
     templateInfo.moveTemplate[3].colorTint = {1,0.2,0.2}
     templateInfo.moveTemplate[3].shortBundle = "http://cloud-3.steamusercontent.com/ugc/1761462778009510243/26BA9DD7881AF63E1A19EB6BF9802630D792F836/"
     templateInfo.moveTemplate[3].longBundle = "http://cloud-3.steamusercontent.com/ugc/1761462778009510200/6723334F35444B547AA1382AE80F12E3FE9B72B1/"
-    templateInfo.moveTemplate[3].sharedBundle = "http://cloud-3.steamusercontent.com/ugc/1761462778009533447/E5D1D5169F0DB6025808BEE8C9647B3E7057BDB9/"
+    templateInfo.moveTemplate[3].sharedBundle = "https://steamusercontent-a.akamaihd.net/ugc/14511655092146905869/6D223BCC7D94DBDD342B6F887F7C777CE47D5585/"
 
     --This is actually diameter... just saying
     templateInfo.baseRadius = {

--- a/mod/src/StarWarsLegion/TABLE.3a3ed9.json
+++ b/mod/src/StarWarsLegion/TABLE.3a3ed9.json
@@ -35,7 +35,7 @@
     "HideWhenFaceDown": false,
     "Hands": false,
     "CustomAssetbundle": {
-      "AssetbundleURL": "http://cloud-3.steamusercontent.com/ugc/1744555589998518180/70BD19FBE4D4D8B319F6A4A2ACCE401C25D94656/",
+      "AssetbundleURL": "https://steamusercontent-a.akamaihd.net/ugc/10056915662299769833/848514DAF6FBC6488078EA9E0A4EB8C4582FCADF/",
       "AssetbundleSecondaryURL": "",
       "MaterialIndex": 0,
       "TypeIndex": 0,


### PR DESCRIPTION
Templates still spawn as expected, but I updated the shaders to hopefully work on mac 
<img width="1340" height="816" alt="image" src="https://github.com/user-attachments/assets/bca703a5-8d86-40db-b094-9b1503e4550f" />
