### PR TITLE
Fix oblong fig_leader PNG URLs missing _stadium suffix

### DIFF
--- a/mod/src/includes/Overlays.ttslua
+++ b/mod/src/includes/Overlays.ttslua
@@ -36,8 +36,8 @@ local RANGE_DECAL_URLS = {
         huge   = ASSETS_BASE .. "range_fig_leader_huge.png",
         laat   = ASSETS_BASE .. "range_fig_leader_laat.png",
         epic   = ASSETS_BASE .. "range_fig_leader_epic.png",
-        long   = ASSETS_BASE .. "range_fig_leader_long.png",
-        snail  = ASSETS_BASE .. "range_fig_leader_snail.png",
+        long   = ASSETS_BASE .. "range_fig_leader_long_stadium.png",
+        snail  = ASSETS_BASE .. "range_fig_leader_snail_stadium.png",
     },
 }
 local RANGE_MAX_RADIUS = {


### PR DESCRIPTION
Overlays.ttslua referenced range_fig_leader_long.png and range_fig_leader_snail.png, but the assets shipped in mod/data/mac-fallback-assets/ are named with the _stadium suffix (consistent with generate_overlay_assets.py output and the inline copy in mac-patcher/patch_save_for_mac.py). TTS hit a GitHub 404 and surfaced "Load image failed unsupported format: UNKNOWN".